### PR TITLE
Update generic array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ optional = true
 version = "~0.1"
 
 [dependencies]
-generic-array = "^0.11"
+generic-array = "^0.14"
 
 [dev-dependencies]
 arraydeque = "0.4.2"


### PR DESCRIPTION
This PR is to address the cargo audit failures due to [RUSTSEC-2020-0146](https://github.com/RustSec/advisory-db/blob/master/crates/generic-array/RUSTSEC-2020-0146.md) in generic-array. I see median doesn't use the affected macro so the vulnerability didn't affect it, but this removes the need for users to verify this themselves